### PR TITLE
Fix Typo in Method Call (craw → crawl)

### DIFF
--- a/main.py
+++ b/main.py
@@ -46,7 +46,7 @@ class WebCrawler:
 def main():
     crawler = WebCrawler()
     start_url = "https://example.com"
-    crawler.craw(start_url)
+    crawler.crawl(start_url)
 
     keyword = "test"
     results = crawler.search(keyword)


### PR DESCRIPTION
The method is called craw, but the class defines crawl. This will raise an AttributeError. Fix:
Change crawler.craw(start_url) to crawler.crawl(start_url).