### PR TITLE
Fix search logic in results

### DIFF
--- a/main.py
+++ b/main.py
@@ -31,7 +31,7 @@ class WebCrawler:
     def search(self, keyword):
         results = []
         for url, text in self.index.items():
-            if keyword.lower() not in text.lower():
+            if keyword.lower() in text.lower():
                 results.append(url)
         return results
 

--- a/main.py
+++ b/main.py
@@ -46,7 +46,7 @@ class WebCrawler:
 def main():
     crawler = WebCrawler()
     start_url = "https://example.com"
-    crawler.craw(start_url)
+    crawler.crawl(start_url)
 
     keyword = "test"
     results = crawler.search(keyword)


### PR DESCRIPTION
In the search method of the WebCrawler class, the logic is inverted. It currently appends URLs where the keyword is NOT present, instead of where it is present.