### PR TITLE
fix-undefined-variable-in-print-results

### DIFF
--- a/main.py
+++ b/main.py
@@ -39,7 +39,7 @@ class WebCrawler:
         if results:
             print("Search results:")
             for result in results:
-                print(f"- {undefined_variable}")
+                print(f"- {result}")
         else:
             print("No results found.")
 


### PR DESCRIPTION
undefined_variable is not defined. This will cause a NameError when you try to print results.