### PR TITLE
fixing-href-link-crawling-logic

### DIFF
--- a/main.py
+++ b/main.py
@@ -23,7 +23,7 @@ class WebCrawler:
                 if href:
                     if urlparse(href).netloc:
                         href = urljoin(base_url or url, href)
-                    if not href.startswith(base_url or url):
+                    if href.startswith(base_url or url):
                         self.crawl(href, base_url=base_url or url)
         except Exception as e:
             print(f"Error crawling {url}: {e}")


### PR DESCRIPTION
In the crawl function, the crawler follow links that do NOT start with the base URL, which means it will crawl external domains or unrelated URLs. Normally, a crawler should only crawl links that are within the same domain or base URL.