### PR TITLE
fixing-duplicate-main-block

### DIFF
--- a/main.py
+++ b/main.py
@@ -104,9 +104,9 @@ class WebCrawlerTests(unittest.TestCase):
 
         # Assert that the output was captured correctly by mock_stdout
 
-if __name__ == "__main__":
-    unittest.main()  # Run unit tests
-    main()  # Run your main application logic 
+# if __name__ == "__main__":
+#     unittest.main()  # Run unit tests
+#     main()  # Run your main application logic 
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
multiple if name == "main": blocks in your file, and both are calling main(). This is redundant and can cause the main logic to run multiple times or in unexpected ways.

If you want to allow running both tests and the main application, you should separate their execution (usually unit tests are not run together with main application logic).